### PR TITLE
feat: Implement DB connection and schema for #6, #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ wheels/
 
 # Environment variables file
 .env
+
+*.db

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ wheels/
 
 # Log files
 logs/
+
+# Database files
+*.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,15 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "duckdb>=1.2.2",
     "pydantic-settings>=2.9.1",
     "pydantic>=2.11.3",
     "python-dotenv>=1.1.0",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,14 @@
+"""
+Database module for Agent Conversation Retrieval System.
+
+Provides access to database connection management and schema initialization.
+"""
+
+from .connection import db_connection, get_db_connection
+from .schema import initialize_database
+
+__all__ = [
+    "db_connection",
+    "get_db_connection",
+    "initialize_database",
+]

--- a/src/db/connection.py
+++ b/src/db/connection.py
@@ -1,0 +1,75 @@
+import logging
+from contextlib import contextmanager
+from typing import Generator
+
+import duckdb
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_db_connection() -> duckdb.DuckDBPyConnection:
+    """
+    DuckDBデータベースへの接続を取得します。
+
+    Returns:
+        duckdb.DuckDBPyConnection: データベース接続オブジェクト。
+
+    Raises:
+        duckdb.Error: データベース接続に失敗した場合。
+    """
+    try:
+        # データベースファイルが存在するディレクトリを作成 (なければ)
+        settings.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        conn = duckdb.connect(database=str(settings.DB_PATH), read_only=False)
+        logger.info(f"Successfully connected to database: {settings.DB_PATH}")
+        return conn
+    except duckdb.Error as e:
+        logger.error(f"Failed to connect to database: {settings.DB_PATH}. Error: {e}")
+        raise
+
+
+@contextmanager
+def db_connection() -> Generator[duckdb.DuckDBPyConnection, None, None]:
+    """
+    データベース接続を管理するコンテキストマネージャ。
+    接続の取得とクローズを自動で行います。
+
+    Yields:
+        duckdb.DuckDBPyConnection: データベース接続オブジェクト。
+
+    Raises:
+        duckdb.Error: データベース接続または切断に失敗した場合。
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        yield conn
+    except duckdb.Error:
+        # get_db_connection内で既にログ出力されているため、ここでは再raiseのみ
+        raise
+    finally:
+        if conn:
+            try:
+                conn.close()
+                logger.info(f"Database connection closed: {settings.DB_PATH}")
+            except duckdb.Error as e:
+                logger.error(
+                    f"Failed to close database connection: {settings.DB_PATH}. Error: {e}"
+                )
+                # クローズ失敗は致命的ではない場合もあるため、ここではログ出力に留める
+                # 必要であれば raise e を追加
+
+
+if __name__ == "__main__":
+    # 簡単な接続テスト
+    logging.basicConfig(level=logging.INFO)
+    try:
+        with db_connection() as conn:
+            logger.info("Connection test successful.")
+            # 簡単なクエリを実行してみる
+            result = conn.execute("SELECT 42;").fetchone()
+            logger.info(f"Query result: {result}")
+    except duckdb.Error as e:
+        logger.error(f"Connection test failed: {e}")

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -1,0 +1,96 @@
+import logging
+
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+# テーブルスキーマ定義 (要件定義書 4.3 準拠)
+# conversations テーブル: 会話の生データ
+CREATE_CONVERSATIONS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS conversations (
+    id INTEGER PRIMARY KEY,                 -- 発話ごとのユニークID (自動採番を想定)
+    session_id VARCHAR NOT NULL,            -- 会話セッションID
+    agent_id VARCHAR NOT NULL,              -- 発話したエージェントのID
+    utterance_text VARCHAR NOT NULL,        -- 発話内容
+    timestamp TIMESTAMP NOT NULL,           -- 発話タイムスタンプ
+    created_at TIMESTAMP DEFAULT current_timestamp -- レコード作成日時
+);
+"""
+
+# conversation_summaries テーブル: 要約とベクトル
+CREATE_CONVERSATION_SUMMARIES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS conversation_summaries (
+    id INTEGER PRIMARY KEY,                 -- 要約ごとのユニークID (自動採番を想定)
+    conversation_session_id VARCHAR NOT NULL, -- 対応する会話セッションID (conversations.session_id と関連)
+    summary_text VARCHAR NOT NULL,          -- 生成された要約テキスト
+    embedding FLOAT[],                      -- 要約テキストの埋め込みベクトル (次元数はモデル依存)
+    created_at TIMESTAMP DEFAULT current_timestamp -- レコード作成日時
+);
+"""
+# TODO: embedding の次元数を設定ファイル等で管理できるようにする
+
+# インデックス定義 (要件定義書 4.3 準拠)
+# ベクトル検索インデックス (HNSW)
+# 注意: DuckDBのvss拡張機能が必要。また、次元数(dims)は埋め込みモデルに合わせる必要がある。
+# 例: CREATE INDEX IF NOT EXISTS summary_embedding_idx ON conversation_summaries USING HNSW (embedding) WITH (dims=1024, metric='cosine');
+# 全文検索インデックス (fts拡張機能)
+# 注意: DuckDBのfts拡張機能と、日本語トークナイザ(例: icu)の連携設定が必要。
+# 例: PRAGMA create_fts_index('conversation_summaries', 'id', 'summary_text', overwrite=1, stemmer='icu', stopwords='none');
+
+
+def initialize_database(connection: duckdb.DuckDBPyConnection):
+    """
+    データベースに必要なテーブルが存在しない場合に作成します。
+
+    Args:
+        connection: DuckDBデータベース接続オブジェクト。
+
+    Raises:
+        duckdb.Error: テーブル作成に失敗した場合。
+    """
+    try:
+        logger.info("Initializing database tables if they don't exist...")
+        connection.execute(CREATE_CONVERSATIONS_TABLE_SQL)
+        logger.info("Checked/Created 'conversations' table.")
+        connection.execute(CREATE_CONVERSATION_SUMMARIES_TABLE_SQL)
+        logger.info("Checked/Created 'conversation_summaries' table.")
+        logger.info("Database initialization complete.")
+        # 注意: インデックス作成はここでは行わない。
+        # ベクトル/全文検索インデックスは、データ挿入後や別途スクリプトで作成することを推奨。
+        # また、必要な拡張機能(vss, fts, icu)のインストールとロードが前提となる。
+    except duckdb.Error as e:
+        logger.error(f"Failed to initialize database tables. Error: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    # 簡単な初期化テスト
+    # スクリプトとして直接実行する場合、同じディレクトリ内の connection を直接インポート
+    try:
+        from connection import db_connection
+    except ImportError:
+        # もし PYTHONPATH が設定されていない場合など
+        logger.error(
+            "Could not import 'connection'. Make sure connection.py is in the same directory."
+        )
+        raise
+
+    logging.basicConfig(level=logging.INFO)
+    logger.info("Running schema initialization test...")
+    try:
+        with db_connection() as conn:
+            initialize_database(conn)
+            logger.info("Schema initialization test successful.")
+            # テーブル構造を確認 (オプション)
+            # print("\nTables:")
+            # print(conn.execute("SHOW TABLES;").fetchall())
+            # print("\nConversations Schema:")
+            # print(conn.execute("DESCRIBE conversations;").fetchall())
+            # print("\nConversation Summaries Schema:")
+            # print(conn.execute("DESCRIBE conversation_summaries;").fetchall())
+    except duckdb.Error as e:
+        logger.error(f"Schema initialization test failed: {e}")
+    except ImportError:
+        logger.error(
+            "Could not import db_connection. Make sure connection.py is in the same directory or PYTHONPATH is set correctly."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -4,8 +4,9 @@ requires-python = ">=3.12"
 [[package]]
 name = "agentconversationretrievalsystem"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
+    { name = "duckdb" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -13,6 +14,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "duckdb", specifier = ">=1.2.2" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
@@ -25,6 +27,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/b8/0f86278684fb7a1fac7c0c869fc6d68ed005cdc91c963eb4373e0551bc0a/duckdb-1.2.2.tar.gz", hash = "sha256:1e53555dece49201df08645dbfa4510c86440339889667702f936b7d28d39e43", size = 11595514 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/25/549f68e55e1b455bd2daf2e5fc912000a3139fe0395111b3d49b23a2cec1/duckdb-1.2.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f745379f44ad302560688855baaed9739c03b37a331338eda6a4ac655e4eb42f", size = 15271882 },
+    { url = "https://files.pythonhosted.org/packages/f6/84/13de7bf9056dcc7a346125d9a9f0f26f76c633db6b54052738f78f828538/duckdb-1.2.2-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:087713fc5958cae5eb59097856b3deaae0def021660c8f2052ec83fa8345174a", size = 31964873 },
+    { url = "https://files.pythonhosted.org/packages/0f/53/c8d2d56a801b7843ea87f8533a3634e6b38f06910098a266f8a096bd4c61/duckdb-1.2.2-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:a1f96395319c447a31b9477881bd84b4cb8323d6f86f21ceaef355d22dd90623", size = 16800653 },
+    { url = "https://files.pythonhosted.org/packages/bb/36/e25791d879fb93b92a56bf481ce11949ab19109103ae2ba12d64e49355d9/duckdb-1.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6aba3bc0acf4f8d52b94f7746c3b0007b78b517676d482dc516d63f48f967baf", size = 18735524 },
+    { url = "https://files.pythonhosted.org/packages/d7/46/4745aa10a1e460f4c8b473eddaffe2c783ac5280e1e5929dd84bd1a1acde/duckdb-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5c1556775a9ebaa49b5c8d64718f155ac3e05b34a49e9c99443cf105e8b0371", size = 20210314 },
+    { url = "https://files.pythonhosted.org/packages/ff/0d/8563fc5ece36252e3d07dd3d29c7a0a034dcf62f14bed7cdc016d95adcbe/duckdb-1.2.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d625cc7d2faacfb2fc83ebbe001ae75dda175b3d8dce6a51a71c199ffac3627a", size = 18755134 },
+    { url = "https://files.pythonhosted.org/packages/11/f1/b7ade7d980eee4fb3ad7469ccf23adb3668a9a28cf3989b24418392d3786/duckdb-1.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:73263f81545c5cb4360fbaf7b22a493e55ddf88fadbe639c43efb7bc8d7554c4", size = 22294397 },
+    { url = "https://files.pythonhosted.org/packages/eb/c9/896e8ced7b408df81e015fe0c6497cda46c92d9dfc8bf84b6d13f5dad473/duckdb-1.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:b1c0c4d737fd2ab9681e4e78b9f361e0a827916a730e84fa91e76dca451b14d5", size = 11370381 },
+    { url = "https://files.pythonhosted.org/packages/41/31/5e2f68cbd000137f6ed52092ad83a8e9c09eca70c59e0b4c5eb679709997/duckdb-1.2.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:fb9a2c77236fae079185a990434cb9d8432902488ba990235c702fc2692d2dcd", size = 15272507 },
+    { url = "https://files.pythonhosted.org/packages/d2/15/aa9078fc897e744e077c0c1510e34db4c809de1d51ddb5cb62e1f9c61312/duckdb-1.2.2-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:d8bb89e580cb9a3aaf42e4555bf265d3db9446abfb118e32150e1a5dfa4b5b15", size = 31965548 },
+    { url = "https://files.pythonhosted.org/packages/9f/28/943773d44fd97055c59b58dde9182733661c2b6e3b3549f15dc26b2e139e/duckdb-1.2.2-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:88916d7f0532dc926bed84b50408c00dcbe6d2097d0de93c3ff647d8d57b4f83", size = 16800600 },
+    { url = "https://files.pythonhosted.org/packages/39/51/2caf01e7791e490290798c8c155d4d702ed61d69e815915b42e72b3e7473/duckdb-1.2.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30bece4f58a6c7bb0944a02dd1dc6de435a9daf8668fa31a9fe3a9923b20bd65", size = 18735886 },
+    { url = "https://files.pythonhosted.org/packages/87/0c/48ae1d485725af3a452303af409a9022d751ecab260cb9ca2f8c9fb670bc/duckdb-1.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bd2c6373b8b54474724c2119f6939c4568c428e1d0be5bcb1f4e3d7f1b7c8bb", size = 20210481 },
+    { url = "https://files.pythonhosted.org/packages/69/c7/95fcd7bde0f754ea6700208d36b845379cbd2b28779c0eff4dd4a7396369/duckdb-1.2.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72f688a8b0df7030c5a28ca6072817c1f090979e08d28ee5912dee37c26a7d0c", size = 18756619 },
+    { url = "https://files.pythonhosted.org/packages/ad/1b/c9eab9e84d4a70dd5f7e2a93dd6e9d7b4d868d3df755cd58b572d82d6c5d/duckdb-1.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26e9c349f56f7c99341b5c79bbaff5ba12a5414af0261e79bf1a6a2693f152f6", size = 22294667 },
+    { url = "https://files.pythonhosted.org/packages/3f/3d/ce68db53084746a4a62695a4cb064e44ce04123f8582bb3afbf6ee944e16/duckdb-1.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:e1aec7102670e59d83512cf47d32a6c77a79df9df0294c5e4d16b6259851e2e9", size = 11370206 },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the basic DuckDB connection module (`src/db`) and defines the table schemas (`conversations`, `conversation_summaries`) as required by issues #6 and #7.

Closes #6
Closes #7